### PR TITLE
feat: docsearch border-radius should respond to customization

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -178,6 +178,23 @@
   background-color: #8b8d98;
 }
 
+/* Override modal style (specificity issue) */
+.DocSearch .DocSearch-Modal {
+  border-radius: var(--radius);
+
+  .DocSearch-Form {
+    border-radius: calc(var(--radius) - 2px);
+  }
+
+  .DocSearch-Hit a {
+    border-radius: calc(var(--radius) - 2px);
+  }
+
+  .DocSearch-Footer {
+    border-radius: var(--radius);
+  }
+}
+
 .DocSearch-Modal {
   --docsearch-highlight-color: hsl(var(--foreground));
   --docsearch-searchbox-shadow: inset 0 0 0 2px hsl(var(--ring));


### PR DESCRIPTION
I missed this one, apologies
search modal now responds to the radius css variable

![image](https://github.com/jolbol1/jolly-ui/assets/83283727/2b24130a-90e2-4482-8858-47db67c740fc)
