### PR TITLE
fix: fix focus ring, add ref, add displayName

### DIFF
--- a/apps/docs/registry/default/ui/button.tsx
+++ b/apps/docs/registry/default/ui/button.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[focused]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
   {
     variants: {
       variant: {
@@ -42,22 +42,26 @@ export interface ButtonProps
   extends _ButtonProps,
     VariantProps<typeof buttonVariants> {}
 
-const Button = ({ className, variant, size, ...props }: ButtonProps) => {
-  return (
-    <_Button
-      className={(values) =>
-        cn(
-          buttonVariants({
-            variant,
-            size,
-            className:
-              typeof className === "function" ? className(values) : className,
-          })
-        )
-      }
-      {...props}
-    />
-  )
-}
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <_Button
+        className={(values) =>
+          cn(
+            buttonVariants({
+              variant,
+              size,
+              className:
+                typeof className === "function" ? className(values) : className,
+            })
+          )
+        }
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/apps/docs/registry/default/ui/button.tsx
+++ b/apps/docs/registry/default/ui/button.tsx
@@ -42,26 +42,22 @@ export interface ButtonProps
   extends _ButtonProps,
     VariantProps<typeof buttonVariants> {}
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
-    return (
-      <_Button
-        className={(values) =>
-          cn(
-            buttonVariants({
-              variant,
-              size,
-              className:
-                typeof className === "function" ? className(values) : className,
-            })
-          )
-        }
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+const Button = ({ className, variant, size, ...props }: ButtonProps) => {
+  return (
+    <_Button
+      className={(values) =>
+        cn(
+          buttonVariants({
+            variant,
+            size,
+            className:
+              typeof className === "function" ? className(values) : className,
+          })
+        )
+      }
+      {...props}
+    />
+  )
+}
 
 export { Button, buttonVariants }

--- a/apps/docs/registry/new-york/ui/button.tsx
+++ b/apps/docs/registry/new-york/ui/button.tsx
@@ -43,26 +43,22 @@ export interface ButtonProps
   extends _ButtonProps,
     VariantProps<typeof buttonVariants> {}
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
-    return (
-      <_Button
-        className={(values) =>
-          cn(
-            buttonVariants({
-              variant,
-              size,
-              className:
-                typeof className === "function" ? className(values) : className,
-            })
-          )
-        }
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+const Button = ({ className, variant, size, ...props }: ButtonProps) => {
+  return (
+    <_Button
+      className={(values) =>
+        cn(
+          buttonVariants({
+            variant,
+            size,
+            className:
+              typeof className === "function" ? className(values) : className,
+          })
+        )
+      }
+      {...props}
+    />
+  )
+}
 
 export { Button, buttonVariants }

--- a/apps/docs/registry/new-york/ui/button.tsx
+++ b/apps/docs/registry/new-york/ui/button.tsx
@@ -10,7 +10,7 @@ import {
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[focused]:outline-none data-[focus-visible]:ring-1 data-[focus-visible]:ring-ring",
   {
     variants: {
       variant: {
@@ -43,22 +43,26 @@ export interface ButtonProps
   extends _ButtonProps,
     VariantProps<typeof buttonVariants> {}
 
-const Button = ({ className, variant, size, ...props }: ButtonProps) => {
-  return (
-    <_Button
-      className={(values) =>
-        cn(
-          buttonVariants({
-            variant,
-            size,
-            className:
-              typeof className === "function" ? className(values) : className,
-          })
-        )
-      }
-      {...props}
-    />
-  )
-}
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => {
+    return (
+      <_Button
+        className={(values) =>
+          cn(
+            buttonVariants({
+              variant,
+              size,
+              className:
+                typeof className === "function" ? className(values) : className,
+            })
+          )
+        }
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
 
 export { Button, buttonVariants }


### PR DESCRIPTION
The behavior of the original button click was different from shadcn, and the focus ring was displayed when clicked.

[![Image from Gyazo](https://i.gyazo.com/038a4b32fbd7c437b8edb08ee6cd380c.gif)](https://gyazo.com/038a4b32fbd7c437b8edb08ee6cd380c)

After the modification, the focus ring is not displayed on click, but is displayed when the keyboard is in focus (data-focus-visible=true).

[![Image from Gyazo](https://i.gyazo.com/72c45f12f06ebe9ce2bb2d22b66a88fd.gif)](https://gyazo.com/72c45f12f06ebe9ce2bb2d22b66a88fd)

Also, since the ref was not received, there was a problem that the ref could not be passed, for example, when replacing a Button called in shadcn's Carousel component with a jolly-ui Button.