### PR TITLE
fix: fix tabs transition

### DIFF
--- a/apps/docs/registry/default/ui/tabs.tsx
+++ b/apps/docs/registry/default/ui/tabs.tsx
@@ -28,7 +28,7 @@ const TabList = ({
 const Tab = ({ className, ...props }: React.ComponentProps<typeof _Tab>) => (
   <_Tab
     className={cn(
-      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus:outline-none data-[disabled]:pointer-events-none data-[selected]:bg-background data-[selected]:text-foreground data-[disabled]:opacity-50 data-[selected]:shadow-sm data-[focus-visible]:outline-none data-[focused]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
+      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition focus:outline-none data-[disabled]:pointer-events-none data-[selected]:bg-background data-[selected]:text-foreground data-[disabled]:opacity-50 data-[selected]:shadow-sm data-[focus-visible]:outline-none data-[focused]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
       className
     )}
     {...props}

--- a/apps/docs/registry/new-york/ui/tabs.tsx
+++ b/apps/docs/registry/new-york/ui/tabs.tsx
@@ -28,7 +28,7 @@ const TabList = ({
 const Tab = ({ className, ...props }: React.ComponentProps<typeof _Tab>) => (
   <_Tab
     className={cn(
-      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus:outline-none data-[disabled]:pointer-events-none data-[selected]:bg-background data-[selected]:text-foreground data-[disabled]:opacity-50 data-[selected]:shadow data-[focus-visible]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
+      "inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition focus:outline-none data-[disabled]:pointer-events-none data-[selected]:bg-background data-[selected]:text-foreground data-[disabled]:opacity-50 data-[selected]:shadow data-[focus-visible]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-ring data-[focus-visible]:ring-offset-2",
       className
     )}
     {...props}


### PR DESCRIPTION
The `transition-all` was apparently being applied to the outline as well, which was causing unnatural behavior.
This was causing unnatural behavior, which was improved by changing it to `transition`.


before:
[![Image from Gyazo](https://i.gyazo.com/2415c5426eed4b2879eb1b27a89b7d8d.gif)](https://gyazo.com/2415c5426eed4b2879eb1b27a89b7d8d)

after:
[![Image from Gyazo](https://i.gyazo.com/422c68b945babaacfc1fc2205430b276.gif)](https://gyazo.com/422c68b945babaacfc1fc2205430b276)