### PR TITLE
fix: demo popover width

### DIFF
--- a/src/components/examples/payment-method-demo.tsx
+++ b/src/components/examples/payment-method-demo.tsx
@@ -108,7 +108,7 @@ export function CardsPaymentMethod() {
               <SelectTrigger id="month" aria-label="Month">
                 <SelectValue />
               </SelectTrigger>
-              <SelectPopover>
+              <SelectPopover className="w-auto">
                 <SelectListBox>
                   <SelectItem textValue="January" id="1">
                     January


### PR DESCRIPTION
It is very nice of JollyUI to come with `.w-[--trigger-width]` by default, however in this specific case `.w-auto` is better:

| Before | After |
|--------|--------|
| <img width="153" alt="Screenshot 2024-09-02 at 5 57 50 PM" src="https://github.com/user-attachments/assets/82176518-d656-4a2a-9e86-4548794f003b"> | <img width="220" alt="Screenshot 2024-09-02 at 5 58 12 PM" src="https://github.com/user-attachments/assets/0a9122bb-8e7d-4fa6-aba4-26efaf9dcd39"> | 


