### PR TITLE
fix radio group with horizontal orientation

### DIFF
--- a/src/registry/default/ui/radio-group.tsx
+++ b/src/registry/default/ui/radio-group.tsx
@@ -93,7 +93,7 @@ function JollyRadioGroup({
   return (
     <RadioGroup
       className={composeRenderProps(className, (className) =>
-        cn("group flex flex-col gap-2", className)
+        cn("group", className)
       )}
       {...props}
     >

--- a/src/registry/new-york/ui/radio-group.tsx
+++ b/src/registry/new-york/ui/radio-group.tsx
@@ -93,7 +93,7 @@ function JollyRadioGroup({
   return (
     <RadioGroup
       className={composeRenderProps(className, (className) =>
-        cn("group flex flex-col gap-2", className)
+        cn("group", className)
       )}
       {...props}
     >


### PR DESCRIPTION
Currently, when you use the `JollyRadioGroupProps` component, you can't set the `orientation` prop to `horizontal` because it's hardcoding the `flex flex-col` classes. 

This PR removes the hardcoded classes so the style is defined by the internal `RadioGroup` component.

Before (vertical):
<img width="977" alt="image" src="https://github.com/user-attachments/assets/81a3c171-f8e0-472d-87c8-7b7655a09521">

Before (horizontal):
<img width="970" alt="image" src="https://github.com/user-attachments/assets/81485132-261f-4435-b34f-5e0c3c74375d">

After (vertical):
<img width="971" alt="image" src="https://github.com/user-attachments/assets/6957c2e9-eb2e-4d2f-9b18-cfa559fd29fe">

After (horizontal):
<img width="968" alt="image" src="https://github.com/user-attachments/assets/a7f6640e-11c3-4842-aefc-b152b63e488a">
